### PR TITLE
Allow multiclass f-score

### DIFF
--- a/src/classification/multiclass.jl
+++ b/src/classification/multiclass.jl
@@ -504,9 +504,9 @@ f_score(targets, outputs, avgmode::AverageMode) =
 Same as [`f_score`](@ref), but with `β` fixed to 1.
 """
 f1_score(targets, outputs) = f_score(targets, outputs, 1.0)
-f1_score(targets, outputs, enc) = f_score(targets, outputs, enc, 1.0)
+f1_score(targets, outputs, enc::LabelEncoding) = f_score(targets, outputs, enc, 1.0)
 f1_score(targets, outputs, avgmode::AverageMode) = f_score(targets, outputs, avgmode)
-f1_score(targets, outputs, enc, avgmode::AverageMode) = f_score(targets, outputs, enc, avgmode, 1.0)
+f1_score(targets, outputs, enc::LabelEncoding, avgmode::AverageMode) = f_score(targets, outputs, enc, avgmode, 1.0)
 
 aggregate_score(score, labels, ::AvgMode.None) = Dict(Pair.(labels, score))
 aggregate_score(score, labels, ::AvgMode.Macro) = mean(score)

--- a/src/classification/multiclass.jl
+++ b/src/classification/multiclass.jl
@@ -395,7 +395,7 @@ end
 # --------------------------------------------------------------------
 
 """
-    f_score(targets, outputs, [encoding], [β = 1]) -> Float64
+    f_score(targets, outputs, [encoding], [avgmode], [β = 1]) -> Float64
 
 Compute the F-score for the `outputs` given the `targets`.
 The F-score is a measure for accessing the quality of binary
@@ -433,7 +433,7 @@ julia> f_score([1,0,0,1,1], [1,-1,-1,-1,1], LabelEnc.FuzzyBinary())
 ```
 """
 function f_score(targets::AbstractVector,
-                 outputs::AbstractArray,
+                 outputs::AbstractVector,
                  encoding::BinaryLabelEncoding,
                  β::Number = 1.0)
     @_dimcheck length(targets) == length(outputs)
@@ -449,19 +449,68 @@ function f_score(targets::AbstractVector,
     (1+β²)*tp / ((1+β²)*tp + β²*fn + fp)
 end
 
+# Micro averaging multiclass f-score
+function f_score(targets::AbstractVector,
+                 outputs::AbstractVector,
+                 encoding::LabelEncoding,
+                 avgmode::AvgMode.Micro,
+                 β::Number = 1.0)
+    r = true_positive_rate(targets, outputs, avgmode = avgmode)
+    p = positive_predictive_value(targets, outputs, avgmode = avgmode)
+    β² = abs2(β)
+    ((1+β²)*(p*r)) / (β²*(p+r))
+end
+
+# Macro averaging multiclass f-score
+function f_score(targets::AbstractVector,
+                 outputs::AbstractVector,
+                 encoding::LabelEncoding,
+                 avgmode::AverageMode,
+                 β::Number = 1.0)
+    @_dimcheck length(targets) == length(outputs)
+    labels = label(encoding)
+    n = length(labels)
+    ovr = [LabelEnc.OneVsRest(l) for l in labels]
+    precision_ = zeros(n)
+    recall_ = zeros(n)
+    @inbounds for j = 1:n
+        recall_[j] = true_positive_rate(targets, outputs, ovr[j])       
+        precision_[j] = positive_predictive_value(targets, outputs, ovr[j])
+    end
+    β² = abs2(β)
+    scores = ((1.0 .+ β²) .* (precision_ .* recall_)) ./ (β² .* (precision_ .+ recall_))
+    aggregate_score(scores, labels, avgmode)
+end
+
+function f_score(targets::AbstractVector,
+                 outputs::AbstractVector,
+                 encoding::LabelEncoding,
+                 β::Number = 1.0)
+    f_score(targets, outputs, encoding, AvgMode.None(), β)
+end
+
 f_score(targets, outputs, labels::AbstractVector, args...) =
     f_score(targets, outputs, LabelEnc.NativeLabels(labels), args...)
 
 f_score(targets, outputs, β::Number = 1.0) =
-    f_score(targets, outputs, comparemode(targets, outputs), β)
+    f_score(targets, outputs, comparemode(targets, outputs), AvgMode.None(), β)
+
+f_score(targets, outputs, avgmode::AverageMode) =
+    f_score(targets, outputs, comparemode(targets, outputs), avgmode, 1.0)
 
 """
-    f1_score(target, output, [encoding]) -> Float64
+    f1_score(targets, outputs, [encoding], [avgmode])
 
 Same as [`f_score`](@ref), but with `β` fixed to 1.
 """
-f1_score(target, output) = f_score(target, output, 1.0)
-f1_score(target, output, enc) = f_score(target, output, enc, 1.0)
+f1_score(targets, outputs) = f_score(targets, outputs, 1.0)
+f1_score(targets, outputs, enc) = f_score(targets, outputs, enc, 1.0)
+f1_score(targets, outputs, avgmode::AverageMode) = f_score(targets, outputs, avgmode)
+f1_score(targets, outputs, enc, avgmode::AverageMode) = f_score(targets, outputs, enc, avgmode, 1.0)
+
+aggregate_score(score, labels, ::AvgMode.None) = Dict(Pair.(labels, score))
+aggregate_score(score, labels, ::AvgMode.Macro) = mean(score)
+aggregate_score(score, labels, ::AvgMode.Micro) = error("AvgMode.Micro is undetermined.")
 
 # --------------------------------------------------------------------
 
@@ -602,4 +651,3 @@ function matthews_corrcoef(target, output)
     denominator = (tp + fp) * (tp + fn) * (tn + fp) * (tn + fn)
     return(numerator / (denominator ^ 0.5))
 end
-

--- a/test/classification.jl
+++ b/test/classification.jl
@@ -75,6 +75,17 @@ for (fun, mask) = ((true_positives,  (0,0,0,1)),
     end
 end
 
+# f_score
+
+y_true = [0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
+y_pred = [0, 1, 0, 1, 0, 1, 0, 1, 2, 2, 1]
+@test f_score(y_true, y_pred) == Dict{Int, Float64}(0 => 0.5714285714285715, 1 => 0.6, 2=>0.8)
+@test f_score(y_true, y_pred, AvgMode.Macro()) ≈ 0.6571428571428571
+@test f_score(y_true, y_pred, AvgMode.Micro()) ≈ 0.6363636363636364
+@test f_score(y_true, y_pred, LabelEnc.NativeLabels(unique(y_true)), AvgMode.Micro()) ≈ 0.6363636363636364
+@test f_score(y_true, y_pred, 2.0) == Dict(0=>0.35714285714285715,2=>0.5,1=>0.375)
+@test sort(collect(keys(f_score(y_true, y_pred, [0, 1, 2])))) == [0, 1, 2]
+
 #=
 @testset "multiclass sanity check" begin
     # We count positive strickly positive matches as positives


### PR DESCRIPTION
Hi!

I made an attempt to allow the f-score to support multi-classifications.

I'm thinking about implementing the same for cohens kappa score. Is that okay with you? Is refactor-0.6 the right branch to be working on?